### PR TITLE
Swift 4 objc selector fix

### DIFF
--- a/EFCountingLabel/Classes/EFCountingLabel.swift
+++ b/EFCountingLabel/Classes/EFCountingLabel.swift
@@ -166,7 +166,7 @@ public class EFCountingLabel: UILabel {
         return self.startingValue + updateVal * (self.destinationValue - self.startingValue)
     }
 
-    public func updateValue(_ timer: Timer) {
+    @objc public func updateValue(_ timer: Timer) {
         // update progress
         let now = Date.timeIntervalSinceReferenceDate
         self.progress = self.progress + now - self.lastUpdate


### PR DESCRIPTION
Apple now requires methods used with `#selector` to be prefixed with `@objc`.

https://developer.apple.com/library/content/documentation/Swift/Conceptual/BuildingCocoaApps/InteractingWithObjective-CAPIs.html#//apple_ref/doc/uid/TP40014216-CH4-ID59